### PR TITLE
Unused rpm cleanup script included

### DIFF
--- a/lib/puppet/provider/package/cmsdist.rb
+++ b/lib/puppet/provider/package/cmsdist.rb
@@ -70,9 +70,10 @@ Puppet::Type.type(:package).provide :cmsdist, :parent => Puppet::Provider::Packa
       execute ["mkdir", "-p", prefix]
       execute ["chown", user, prefix]
     rescue Exception => e
-      Puppet.debug("Fetching bootstrap from #{repository}")
+      Puppet.warning "Unable to create / find installation area. Please check your install_options."
       raise e
     end
+    Puppet.debug("Fetching bootstrap from #{repository}")
     execute ["wget", "--no-check-certificate", "-O",
              File.join([prefix, "bootstrap-#{architecture}.sh"]),
              "#{server}/#{server_path}/bootstrap.sh"]


### PR DESCRIPTION
1. In first step deploy new cmsdist module and let is run for few days
   so that it can collect the information about the explicitly install
   package. Basically it create <prefix>/.cmsdistrc directory and keep
   track of all explicitly installed package in it (by creating
   PKG_<package-name> file).
2. Once we have this run for few days then we deploy a new version of
   cmsdist module where we actually enable the unused cms rpm cleanup
   script.